### PR TITLE
Task 2.1a - New Alcohol class implementation with strength_ class member

### DIFF
--- a/shm/inc/alcohol.hpp
+++ b/shm/inc/alcohol.hpp
@@ -6,12 +6,15 @@
 #include "cargo.hpp"
 #include "time.hpp"
 
-class Alcohol : public Cargo
-{
+namespace {
+constexpr size_t MAX_STRENGTH = 96;
+}
+
+class Alcohol : public Cargo {
 public:
-    Alcohol(const std::string& name, size_t amount, size_t basePrice, size_t timeToSpoil, Time* time)
+    Alcohol(const std::string& name, size_t amount, size_t basePrice, size_t strength, Time* time)
         : Cargo(name, amount, basePrice, time),
-          timeToSpoil_(timeToSpoil)
+          strength_(strength)
     {
     }
 
@@ -26,14 +29,12 @@ public:
     std::string getName() const override;
     size_t getAmount() const override;
     size_t getBasePrice() const override;
-    size_t getTimeToSpoil() const;
-    size_t getTimeToSpoilLeft() const;
+    size_t getStrength () const;
 
     std::unique_ptr<Cargo> clone() override;
 
-    void nextDay() {}
+    void nextDay();
 
 private:
-    const size_t timeToSpoil_;
-    size_t timeToSpoilLeft_ = timeToSpoil_;
+    const size_t strength_;
 };

--- a/shm/src/alcohol.cpp
+++ b/shm/src/alcohol.cpp
@@ -2,8 +2,7 @@
 
 size_t Alcohol::getPrice() const
 {
-    return static_cast<size_t>((static_cast<float>(timeToSpoilLeft_) / static_cast<float>(timeToSpoil_)) *
-                               static_cast<float>(basePrice_));
+    return static_cast<size_t>(static_cast<size_t>(basePrice_) * (strength_ / MAX_STRENGTH));
 }
 
 std::string Alcohol::getName() const
@@ -18,26 +17,22 @@ size_t Alcohol::getBasePrice() const
 {
     return basePrice_;
 }
-size_t Alcohol::getTimeToSpoil() const
+size_t Alcohol::getStrength() const
 {
-    return timeToSpoil_;
-}
-size_t Alcohol::getTimeToSpoilLeft() const
-{
-    return timeToSpoilLeft_;
+    return strength_;
 }
 
 Alcohol& Alcohol::operator--()
 {
-    if (timeToSpoilLeft_ > 0) {
-        --timeToSpoilLeft_;
+    if (amount_ > 0) {
+        --amount_;
     }
     return *this;
 }
 Alcohol& Alcohol::operator--(int)
 {
     Alcohol& temp(*this);
-    if (timeToSpoilLeft_ > 0) {
+    if (amount_ > 0) {
         operator--();
     }
     return temp;
@@ -46,9 +41,10 @@ bool Alcohol::operator==(const Cargo& cargo) const
 {
     if (typeid(cargo) == typeid(Alcohol)) {
         const Alcohol* alcohol = static_cast<const Alcohol*>(&cargo);
-        return name_ == alcohol->getName() && amount_ == alcohol->getAmount() &&
-               basePrice_ == alcohol->getBasePrice() && timeToSpoil_ == alcohol->getTimeToSpoil() &&
-               timeToSpoilLeft_ == alcohol->getTimeToSpoilLeft();
+        return name_ == alcohol->getName() &&
+               amount_ == alcohol->getAmount() &&
+               basePrice_ == alcohol->getBasePrice() &&
+               strength_ == alcohol->getStrength();
     }
     return false;
 }
@@ -78,4 +74,9 @@ std::unique_ptr<Cargo> Alcohol::clone()
 {
     std::unique_ptr<Alcohol> alcohol = std::make_unique<Alcohol>(*this);
     return alcohol;
+}
+
+void Alcohol::nextDay()
+{
+    return;
 }

--- a/shm/src/item.cpp
+++ b/shm/src/item.cpp
@@ -53,7 +53,10 @@ Cargo& Item::operator-=(size_t amount)
     return *this;
 }
 
-void Item::nextDay() {}
+void Item::nextDay()
+{
+    return;
+}
 
 std::unique_ptr<Cargo> Item::clone()
 {

--- a/shm/src/store.cpp
+++ b/shm/src/store.cpp
@@ -192,8 +192,8 @@ std::ostream& operator<<(std::ostream& out, const Store& store)
             }
         } else if (typeid(*cargo) == typeid(Alcohol)) {
             Alcohol* alcohol = static_cast<Alcohol*>(cargo.get());
-            out << "Current price: " << alcohol->getPrice() << '\n';
-            out << "Expires in: " << alcohol->getTimeToSpoilLeft() << '\n';
+            out << "Strength: " << alcohol->getStrength() << '\n';
+            out << "Price: " << alcohol->getPrice() << '\n';
         }
     }
     return out;


### PR DESCRIPTION
Change due the nature of alcohol which actually do not spoil thus timeToSpoil_ and timeToSpoilLeft_ variables are not needed. In the new version there is no need to implement nextDay() because there is no change in product the next day (the method returns nothing then).